### PR TITLE
Improve UI; sundry changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You don't need to build to contribute, but if you want to build the HTML and see
 
 3. Clone the repo:
 
-	git clone git@github.com:mikemaccana/rosetta-stone.git
+	git clone git@github.com:certsimple/rosetta-stone.git
 
 3. Edit `rosettastone.md`
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,7 @@ gulp.task('webserver', function() {
   gulp.src('./')
     .pipe(webserver({
       livereload: true,
+      host: '0.0.0.0',
       port: 7777,
       fallback: 'html/index.html',
       open: true

--- a/mustache/template.mustache
+++ b/mustache/template.mustache
@@ -4,7 +4,7 @@
 		<h2>A comparison for current operating systems inspired by the classic Unix Rosetta Stone</h2>
 
 		<div class="chop-box">
-		<a class="edit-me" href="https://github.com/mikemaccana/rosetta-stone">Edit me!</a>
+		<a class="edit-me" href="https://github.com/certsimple/rosetta-stone">Edit me!</a>
 		</div>
 
 		<p class="sponsor">By CertSimple: <a href="/">fast painless EV SSL</a></p>
@@ -21,7 +21,7 @@
 				<img data-operating-system="{{os}}" src="images/rosetta-stone/{{ operatingSystems[os].logo }}-fade.svg">
 			{{/}}
 		{{/}}
-	<p class="aside">All commands below are for the latest server or 'long-term' versions. Want to <a href="https://github.com/mikemaccana/rosetta-stone">add or change something?</a></p>
+	<p class="aside">All commands below are for the latest server or 'long-term' versions. Want to <a href="https://github.com/certsimple/rosetta-stone">add or change something?</a></p>
 </div>
 
 {{#if isAnOSEnabled }}

--- a/mustache/template.mustache
+++ b/mustache/template.mustache
@@ -28,6 +28,7 @@
   <div class="commands">
   	{{#sections:title}}
   		<h2>{{ title }}</h2>
+      <div class="table-container">
   			<table>
   				<thead>
   					<tr>
@@ -56,6 +57,7 @@
   					{{/}}
   				</tbody>
   			</table>
+      </div>
 
   	{{/}}
   </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rosetta-stone",
   "version": "1.6.4",
   "description": "Convert command line tasks between common Operating Systems",
-  "repository": "https://github.com/mikemaccana/rosetta-stone.git",
+  "repository": "https://github.com/certsimple/rosetta-stone.git",
   "dependencies": {
     "brfs": "^1.4.0",
     "browserify": "^10.2.4",

--- a/scss/rosetta-stone.scss
+++ b/scss/rosetta-stone.scss
@@ -146,101 +146,103 @@ code {
 
 .commands {
 	max-width: 100%;
-	overflow: scroll;
 	h2 {
 		padding: 12px;
 	}
 }
 
 // Technique from: https://techblog.livingsocial.com/blog/2015/04/06/responsive-tables-in-pure-css
-table {
-	margin: 12px;
-	padding: 0;
-	border-collapse: collapse;
-	border-spacing: 0;
-	tr {
-		border-bottom: 1px solid $black;
-	}
-	th, td {
-		padding: 10px;
-		text-align: center;
-		// min-width and max-width are required, even despite width setting
-		//  - tables are magic.
-		min-width: $cell-width;
-		max-width: 400px;
-		width: $cell-width;
-		padding: 10px;
-		text-align: center;
-
-		overflow: scroll;
-	}
-	tbody {
-		// Only for headers inside tbody
-		td, th {
-			border-left: 1px solid $black;
-			border-right: 1px solid $black;
-		}
-	}
-	td {
-
-		// References
-		a {
-			float: right;
-			display: block;
-			text-transform: uppercase;
-			text-decoration: none;
-			color: $mid-grey;
-			font-size: 8pt;
-			&:hover, &:active, &:visited {
-				color: $mid-grey;
-			}
-		}
-	}
-	th {
-		text-transform: uppercase;
-		font-size: 14px;
-		letter-spacing: 1px;
-	}
-}
-@media screen and (max-width: $single-column-max-width) {
-	.commands {
-		padding: 12px;
-	}
+.table-container {
+	overflow-x: scroll; 
 	table {
-		width: 100%;
-		margin: 0;
-		border: 0;
-		thead {
-			display: none;
-		}
+		margin: 12px;
+		padding: 0;
+		border-collapse: collapse;
+		border-spacing: 0;
 		tr {
-			margin-bottom: 10px;
-			display: block;
 			border-bottom: 1px solid $black;
-			th {
-				border-top: 1px solid $black;
-			}
 		}
 		th, td {
-			display: block;
-			width: auto;
-			max-width: none;
-			min-width: none;
+			padding: 10px;
+			text-align: center;
+			// min-width and max-width are required, even despite width setting
+			//	- tables are magic.
+			min-width: $cell-width;
+			max-width: 400px;
+			width: $cell-width;
+			padding: 10px;
+			text-align: center;
+
+			overflow: scroll;
+		}
+		tbody {
+			// Only for headers inside tbody
+			td, th {
+				border-left: 1px solid $black;
+				border-right: 1px solid $black;
+			}
 		}
 		td {
-			text-align: right;
-			font-size: 13px;
-			border-bottom: 1px dotted $mid-grey;
-		}
-		td:last-child {
-			border-bottom: 0;
-		}
 
-		td:before {
-			content: attr(data-label);
-			float: left;
+			// References
+			a {
+				float: right;
+				display: block;
+				text-transform: uppercase;
+				text-decoration: none;
+				color: $mid-grey;
+				font-size: 8pt;
+				&:hover, &:active, &:visited {
+					color: $mid-grey;
+				}
+			}
+		}
+		th {
 			text-transform: uppercase;
-			font-weight: bold;
+			font-size: 14px;
+			letter-spacing: 1px;
+		}
+	}
+	@media screen and (max-width: $single-column-max-width) {
+		.commands {
+			padding: 12px;
+		}
+		table {
+			width: 100%;
+			margin: 0;
+			border: 0;
+			thead {
+				display: none;
+			}
+			tr {
+				margin-bottom: 10px;
+				display: block;
+				border-bottom: 1px solid $black;
+				th {
+					border-top: 1px solid $black;
+				}
+			}
+			th, td {
+				display: block;
+				width: auto;
+				max-width: none;
+				min-width: none;
+			}
+			td {
+				text-align: right;
+				font-size: 13px;
+				border-bottom: 1px dotted $mid-grey;
+			}
+			td:last-child {
+				border-bottom: 0;
+			}
+
+			td:before {
+				content: attr(data-label);
+				float: left;
+				text-transform: uppercase;
+				font-weight: bold;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Three commits in this PR. One major:
- Instead of scrolling the container with all the command tables in it, scroll each table individually
  
  Scrolling the whole container works well only for those browsing on phones, tablets, or laptops whose touchpads support drag-scrolling; for anyone else, the height of the container puts the horizontal scrollbar at the bottom of the page's vertical scroll distance, which is if not entirely unusable then at least really annoying. This works for everyone. I can see an argument that it works less well for those browsing from drag- or touch-scrollable devices, but that seems like an acceptable tradeoff for the benefit to those who aren't.

And two minor:
- Update repo references from "mikemaccana" to "certsimple". (Github transparently redirects, but why rely on that?)
- Have the Gulp webserver listen on all interfaces, not just loopback (since not everyone develops on localhost)
